### PR TITLE
Add two-TD prediction tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# gamblebot
+# Gamblebot
+
+Command line tool to identify NFL players with the best value on 2+ touchdown scorer props.
+
+## Usage
+
+Install dependencies and ensure an environment variable `THEODDS_API_KEY` is set for [TheOddsAPI](https://theoddsapi.com/).
+
+```
+poetry install  # or pip install .
+export THEODDS_API_KEY=your_key
+```
+
+Run the weekly report:
+
+```
+two-td report --season 2025 --week 1 --top 10 --books fanduel,draftkings
+```
+
+The command prints a ranked table and optionally exports to CSV/HTML/PNG.

--- a/gamblebot/__init__.py
+++ b/gamblebot/__init__.py
@@ -1,0 +1,12 @@
+"""Gamblebot: tools for NFL touchdown prop analysis."""
+
+__all__ = [
+    "data",
+    "features",
+    "model",
+    "odds",
+    "reporting",
+    "staking",
+]
+
+__version__ = "0.1.0"

--- a/gamblebot/cli.py
+++ b/gamblebot/cli.py
@@ -1,0 +1,64 @@
+"""Command line interface for two touchdown report."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from . import data, features, model, odds, reporting, staking
+
+
+@click.group()
+def main() -> None:
+    """Gamblebot CLI."""
+
+
+@main.command()
+@click.option("--season", type=int, required=True, help="Season year e.g. 2025")
+@click.option("--week", type=int, required=True, help="Week number")
+@click.option("--top", type=int, default=10, show_default=True, help="Top N players")
+@click.option("--books", type=str, default="", help="Comma separated list of books")
+@click.option("--kelly-fraction", type=float, default=0.5, show_default=True)
+@click.option("--unit-size", type=float, default=1.0, show_default=True)
+@click.option("--csv", type=click.Path(path_type=Path), help="Export to CSV")
+@click.option("--html", type=click.Path(path_type=Path), help="Export to HTML")
+@click.option("--png", type=click.Path(path_type=Path), help="Export to PNG")
+def report(
+    season: int,
+    week: int,
+    top: int,
+    books: str,
+    kelly_fraction: float,
+    unit_size: float,
+    csv: Optional[Path],
+    html: Optional[Path],
+    png: Optional[Path],
+) -> None:
+    """Generate a top-N report for 2+ TD scorer edges."""
+    api_key = os.environ.get("THEODDS_API_KEY")
+    if not api_key:
+        raise click.UsageError("THEODDS_API_KEY environment variable not set")
+
+    weekly = data.load_weekly_player_stats(season)
+    td_rate = features.compute_td_rate(weekly)
+    model_df = model.add_model_probability(td_rate)
+
+    client = odds.TheOddsAPIClient(api_key)
+    books_list = [b.strip() for b in books.split(",") if b.strip()] or None
+    odds_df = client.fetch_two_td_odds(season, week, books_list)
+    odds_df = odds.normalize_book_odds(odds_df)
+
+    merged = model_df.merge(odds_df, on="player")
+    merged = staking.add_edge_and_stake(
+        merged, kelly_fraction=kelly_fraction, unit_size=unit_size
+    )
+    merged = merged.sort_values("edge", ascending=False).head(top)
+
+    reporting.display_report(merged)
+    reporting.export_report(merged, csv=csv, html=html, png=png)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/gamblebot/data.py
+++ b/gamblebot/data.py
@@ -1,0 +1,25 @@
+"""Data loading utilities using nfl_data_py with simple caching."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional
+
+import pandas as pd
+import requests_cache
+from nfl_data_py import import_pbp_data, import_weekly_data
+
+# Cache HTTP requests for 12 hours
+requests_cache.install_cache("nfl_cache", expire_after=12 * 60 * 60)
+
+
+@lru_cache(maxsize=32)
+def load_pbp(season: int) -> pd.DataFrame:
+    """Load play-by-play data for a season."""
+    return import_pbp_data([season])
+
+
+@lru_cache(maxsize=128)
+def load_weekly_player_stats(season: int, week: Optional[int] = None) -> pd.DataFrame:
+    """Load weekly player stats for a season and optionally a week."""
+    weeks = [week] if week is not None else None
+    return import_weekly_data(years=[season], weeks=weeks)

--- a/gamblebot/features.py
+++ b/gamblebot/features.py
@@ -1,0 +1,28 @@
+"""Feature engineering for player touchdown rates."""
+from __future__ import annotations
+
+import pandas as pd
+
+
+def compute_td_rate(weekly: pd.DataFrame) -> pd.DataFrame:
+    """Compute a player's historical touchdown rate (λ).
+
+    Parameters
+    ----------
+    weekly: pandas.DataFrame
+        Weekly player stats from :func:`nfl_data_py.import_weekly_data`.
+    """
+    # touchdowns per game
+    weekly = weekly.copy()
+    weekly["td"] = weekly["rushing_td"].fillna(0) + weekly["receiving_td"].fillna(0)
+    grouped = (
+        weekly.groupby(["player_id", "player_display_name", "recent_team"], as_index=False)
+        .agg(td=("td", "sum"), games=("week", "nunique"))
+    )
+    grouped["lambda"] = grouped["td"] / grouped["games"].clip(lower=1)
+    return grouped.rename(
+        columns={
+            "player_display_name": "player",
+            "recent_team": "team",
+        }
+    )[["player_id", "player", "team", "lambda"]]

--- a/gamblebot/model.py
+++ b/gamblebot/model.py
@@ -1,0 +1,17 @@
+"""Modeling utilities using a Poisson distribution."""
+from __future__ import annotations
+
+import math
+import pandas as pd
+
+
+def prob_two_plus(lmbda: float) -> float:
+    """Probability of at least two touchdowns given rate λ."""
+    return 1 - math.exp(-lmbda) * (1 + lmbda)
+
+
+def add_model_probability(td_rate: pd.DataFrame) -> pd.DataFrame:
+    """Add Poisson two+ TD probability to dataframe."""
+    td_rate = td_rate.copy()
+    td_rate["model_prob"] = td_rate["lambda"].apply(prob_two_plus)
+    return td_rate

--- a/gamblebot/odds.py
+++ b/gamblebot/odds.py
@@ -1,0 +1,76 @@
+"""Odds fetching utilities for sportsbook integration."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+import pandas as pd
+import requests_cache
+import requests
+
+
+@dataclass
+class TheOddsAPIClient:
+    """Simple client for TheOddsAPI."""
+
+    api_key: str
+    base_url: str = "https://api.the-odds-api.com/v4"
+
+    def __post_init__(self) -> None:
+        self.session = requests_cache.CachedSession("odds_cache", expire_after=5 * 60)
+
+    def fetch_two_td_odds(
+        self, season: int, week: int, books: Optional[Iterable[str]] = None
+    ) -> pd.DataFrame:
+        """Fetch 2+ TD odds for all players for a given week."""
+        params = {
+            "apiKey": self.api_key,
+            "regions": "us",
+            "markets": "player_two_td",
+            "oddsFormat": "american",
+        }
+        if books:
+            params["bookmakers"] = ",".join(books)
+        url = f"{self.base_url}/sports/americanfootball_nfl/odds"
+        resp = self.session.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        rows = []
+        for event in data:
+            for bm in event.get("bookmakers", []):
+                book = bm["key"]
+                for market in bm.get("markets", []):
+                    for outcome in market.get("outcomes", []):
+                        player = outcome.get("name")
+                        price = outcome.get("price")
+                        rows.append({
+                            "player": player,
+                            "book": book,
+                            "odds": price,
+                        })
+        df = pd.DataFrame(rows)
+        df["implied_prob"] = df["odds"].apply(american_to_implied)
+        return df
+
+
+def american_to_implied(odds: int | float) -> float:
+    """Convert American odds to implied probability."""
+    odds = float(odds)
+    if odds > 0:
+        return 100 / (odds + 100)
+    else:
+        return -odds / (-odds + 100)
+
+
+def american_to_decimal(odds: int | float) -> float:
+    odds = float(odds)
+    if odds > 0:
+        return 1 + odds / 100
+    else:
+        return 1 - 100 / odds
+
+
+def normalize_book_odds(df: pd.DataFrame) -> pd.DataFrame:
+    """Keep the best (lowest implied probability) odds per player."""
+    idx = df.groupby("player")["implied_prob"].idxmin()
+    return df.loc[idx].reset_index(drop=True)

--- a/gamblebot/reporting.py
+++ b/gamblebot/reporting.py
@@ -1,0 +1,48 @@
+"""Reporting utilities for console and file outputs."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+from rich.console import Console
+from rich.table import Table
+
+try:  # optional dependency for PNG export
+    import dataframe_image as dfi
+except Exception:  # pragma: no cover - best effort
+    dfi = None
+
+
+console = Console()
+
+
+def format_percentage(x: float) -> str:
+    return f"{x:.1%}"
+
+
+def display_report(df: pd.DataFrame) -> None:
+    table = Table(show_header=True, header_style="bold")
+    for col in ["team", "player", "model_prob", "odds", "implied_prob", "edge", "stake_units"]:
+        table.add_column(col)
+    for _, row in df.iterrows():
+        table.add_row(
+            row["team"],
+            row["player"],
+            format_percentage(row["model_prob"]),
+            str(row["odds"]),
+            format_percentage(row["implied_prob"]),
+            format_percentage(row["edge"]),
+            f"{row['stake_units']:.2f}",
+        )
+    console.print(table)
+
+
+def export_report(df: pd.DataFrame, csv: Optional[Path] = None, html: Optional[Path] = None, png: Optional[Path] = None) -> None:
+    if csv:
+        df.to_csv(csv, index=False)
+    if html:
+        df.to_html(html, index=False)
+    if png and dfi is not None:
+        dfi.export(df, png)
+

--- a/gamblebot/staking.py
+++ b/gamblebot/staking.py
@@ -1,0 +1,25 @@
+"""Staking utilities using the Kelly criterion."""
+from __future__ import annotations
+
+import pandas as pd
+
+from .odds import american_to_decimal
+
+
+def add_edge_and_stake(
+    df: pd.DataFrame,
+    *,
+    kelly_fraction: float = 0.5,
+    unit_size: float = 1.0,
+) -> pd.DataFrame:
+    """Add edge and Kelly stake columns."""
+    df = df.copy()
+    df["edge"] = df["model_prob"] - df["implied_prob"]
+    decimal_odds = df["odds"].apply(american_to_decimal)
+    df["kelly"] = (
+        (df["model_prob"] * (decimal_odds - 1) - (1 - df["model_prob"]))
+        / (decimal_odds - 1)
+    )
+    df["kelly"] = df["kelly"].clip(lower=0)
+    df["stake_units"] = df["kelly"] * kelly_fraction * unit_size
+    return df.drop(columns=["kelly"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "gamblebot"
+version = "0.1.0"
+description = "NFL 2+ touchdown prop analysis tool"
+authors = [{name = "AutoGen"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "nfl_data_py",
+    "pandas",
+    "requests-cache",
+    "click",
+    "rich",
+]
+
+[project.optional-dependencies]
+report = ["dataframe-image"]
+
+[project.scripts]
+"two-td" = "gamblebot.cli:main"


### PR DESCRIPTION
## Summary
- implement gamblebot package for two-plus touchdown prop analysis
- support odds fetching, Poisson modeling, Kelly staking, and reporting
- add CLI `two-td report` for weekly top-10 edges and export options

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bade5f4af48327a5f54fca6d73b7ad