### PR TITLE
Add sacks report for 1+ sack props

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 2+ TD Report
 
-Generate a ranked list of NFL players with value to score **2+ touchdowns** in a given week, combining a simple Poisson model with sportsbook prices.
+Generate a ranked list of NFL players with value to score **2+ touchdowns** in a given week, combining a simple Poisson model with sportsbook prices. A parallel `sacks` command surfaces defenders with value to record **1+ sack**.
 
 ---
 
@@ -78,6 +78,24 @@ Show every posted **2+ TD** price (debug/sanity check):
 ```bash
 poetry run gamblebot report --season 2025 --week 1 --dump-odds
 ```
+
+---
+
+## 1+ Sack Report
+
+Generate a ranked list of defenders with value to record **1+ sack** in a given week:
+
+```bash
+poetry run gamblebot sacks --season <YEAR> --week <WEEK>
+```
+
+Key options mirror the touchdown report but tailored to pass rushers:
+
+* `--positions` (default: `EDGE,DL,LB`) – defensive positions to include.
+* `--min-passrush-snaps` – minimum recent pass-rush snaps to qualify.
+* `--dump-odds` – print all posted 1+ sack lines (by book) and exit.
+
+Output columns: `player`, `team`, `opponent`, `model_prob`, `line`, `odds`, `implied_prob`, `edge`, `stake_units`.
 
 ---
 

--- a/gamblebot/cli.py
+++ b/gamblebot/cli.py
@@ -9,7 +9,7 @@ import click
 import pandas as pd
 
 from . import data, features, model, odds, reporting, staking
-from .filters import apply_filters
+from .filters import apply_filters, apply_passrush_filters
 
 
 @click.group()
@@ -104,6 +104,107 @@ def report(
 
     rows = client.fetch_two_td_odds(season, week, books_list)
     odds_df = odds.normalize_book_odds(rows)
+
+    merged = filtered.merge(odds_df, on="player")
+    merged = staking.add_edge_and_stake(
+        merged, kelly_fraction=kelly_fraction, unit_size=unit_size
+    )
+    merged = merged.sort_values("edge", ascending=False).head(top)
+
+    reporting.display_report(merged)
+    reporting.export_report(merged, csv=csv, html=html, png=png)
+
+
+@main.command()
+@click.option("--season", type=int, required=True, help="Season year e.g. 2025")
+@click.option("--week", type=int, required=True, help="Week number")
+@click.option("--top", type=int, default=10, show_default=True, help="Top N players")
+@click.option("--books", type=str, default="", help="Comma separated list of books")
+@click.option("--kelly-fraction", type=float, default=0.5, show_default=True)
+@click.option("--unit-size", type=float, default=1.0, show_default=True)
+@click.option("--csv", type=click.Path(path_type=Path), help="Export to CSV")
+@click.option("--html", type=click.Path(path_type=Path), help="Export to HTML")
+@click.option("--png", type=click.Path(path_type=Path), help="Export to PNG")
+@click.option("--dump-odds", is_flag=True, help="Print all available 1+ sack lines and exit")
+@click.option(
+    "--positions",
+    type=str,
+    default="EDGE,DL,LB",
+    show_default=True,
+    help="Comma-separated list of defensive positions to include.",
+)
+@click.option(
+    "--min-passrush-snaps",
+    type=float,
+    default=20.0,
+    show_default=True,
+    help="Minimum recent pass-rush snaps.",
+)
+@click.option("--no-exclude-injured", is_flag=True, help="Do NOT exclude injured players")
+def sacks(
+    season: int,
+    week: int,
+    top: int,
+    books: str,
+    kelly_fraction: float,
+    unit_size: float,
+    csv: Optional[Path],
+    html: Optional[Path],
+    png: Optional[Path],
+    dump_odds: bool,
+    positions: str,
+    min_passrush_snaps: float,
+    no_exclude_injured: bool,
+) -> None:
+    """Generate a top-N report for defenders to record 1+ sack."""
+    api_key = os.environ.get("THEODDS_API_KEY")
+    if not api_key:
+        raise click.UsageError("THEODDS_API_KEY environment variable not set")
+
+    client = odds.TheOddsAPIClient(api_key)
+    books_list = [b.strip() for b in books.split(",") if b.strip()] or None
+
+    if dump_odds:
+        rows = client.fetch_sack_odds(season, week, books_list)
+        df = pd.DataFrame(rows)
+        if df.empty:
+            click.echo("No 1+ sack odds found for the selected week/filters.")
+            return
+        cols = [
+            c
+            for c in [
+                "player",
+                "book",
+                "odds",
+                "implied_prob",
+                "line",
+                "market",
+                "event_id",
+                "home_team",
+                "away_team",
+            ]
+            if c in df.columns
+        ]
+        df = df[cols].sort_values(["player", "book"]).reset_index(drop=True)
+        click.echo(df.to_string(index=False))
+        return
+
+    weekly = data.load_weekly_player_stats(season, week=week)
+    feats = features.compute_sack_features(weekly, season)
+    model_df = model.add_sack_model_probability(feats)
+
+    pos_list = [p.strip() for p in positions.split(",") if p.strip()]
+    filtered = apply_passrush_filters(
+        model_df,
+        positions=pos_list,
+        min_passrush_snaps=min_passrush_snaps,
+        exclude_injured=(not no_exclude_injured),
+        season=season,
+        week=week,
+    )
+
+    rows = client.fetch_sack_odds(season, week, books_list)
+    odds_df = odds.normalize_sack_odds(rows)
 
     merged = filtered.merge(odds_df, on="player")
     merged = staking.add_edge_and_stake(

--- a/gamblebot/features.py
+++ b/gamblebot/features.py
@@ -1,4 +1,4 @@
-"""Feature engineering for 2+ TD modeling."""
+"""Feature engineering utilities for touchdown and sack props."""
 from __future__ import annotations
 
 import pandas as pd
@@ -85,4 +85,116 @@ def compute_td_rate(weekly: pd.DataFrame, *, recent_window: int = 4) -> pd.DataF
     out["recent_opps"] = pd.to_numeric(out["recent_opps"], errors="coerce").fillna(0.0)
 
     return out[["player", "team", "position", "games", "two_plus", "mean_td", "recent_opps"]]
+
+
+def _nz_float(df: pd.DataFrame, colnames: list[str]) -> pd.Series:
+    vals = None
+    for c in colnames:
+        if c in df.columns:
+            s = pd.to_numeric(df[c], errors="coerce").fillna(0.0)
+            vals = s if vals is None else (vals + s)
+    return (vals if vals is not None else pd.Series(0.0, index=df.index)).astype(float)
+
+
+def _team_dropback_sack_rates(season: int) -> pd.DataFrame:
+    """Compute last season's team dropbacks and sack rate allowed with shrinkage."""
+    from . import data  # local import to avoid circular
+
+    try:
+        pbp = data.load_pbp(season)
+    except Exception:
+        return pd.DataFrame(columns=["team", "dropbacks_per_game", "sack_rate"])
+
+    dropbacks = _nz_float(pbp, ["dropback"])
+    sacks = _nz_float(pbp, ["sack"])
+    team_col = _first_nonempty_col(pbp, "posteam", "offense", "pos_team")
+    week_col = _first_nonempty_col(pbp, "week", "game_week")
+    if team_col is None or week_col is None:
+        return pd.DataFrame(columns=["team", "dropbacks_per_game", "sack_rate"])
+
+    agg = (
+        pbp.assign(dropbacks=dropbacks, sacks=sacks)
+        .groupby([team_col, week_col], as_index=False)
+        .agg(dropbacks=("dropbacks", "sum"), sacks=("sacks", "sum"))
+    )
+    team_agg = (
+        agg.groupby(team_col, as_index=False)
+        .agg(dropbacks=("dropbacks", "sum"), sacks=("sacks", "sum"), games=(week_col, "nunique"))
+    )
+    team_agg["dropbacks_per_game"] = team_agg["dropbacks"] / team_agg["games"].clip(lower=1)
+    team_agg["sack_rate"] = team_agg.apply(
+        lambda r: (r["sacks"] / r["dropbacks"]) if r["dropbacks"] > 0 else 0.0, axis=1
+    )
+
+    league_dropbacks = team_agg["dropbacks_per_game"].mean()
+    league_sack_rate = team_agg["sack_rate"].mean()
+    prior_strength = 8.0
+    w = team_agg["games"] / (team_agg["games"] + prior_strength)
+    team_agg["dropbacks_per_game"] = w * team_agg["dropbacks_per_game"] + (1 - w) * league_dropbacks
+    team_agg["sack_rate"] = w * team_agg["sack_rate"] + (1 - w) * league_sack_rate
+
+    return team_agg.rename(columns={team_col: "team"})[["team", "dropbacks_per_game", "sack_rate"]]
+
+
+def compute_sack_features(weekly: pd.DataFrame, season: int, *, recent_window: int = 4) -> pd.DataFrame:
+    """Compute defender pass-rush features for the sacks report."""
+    df = weekly.copy()
+
+    player_col = _first_nonempty_col(df, "player", "player_display_name", "full_name", "name")
+    if not player_col:
+        raise KeyError("Could not find a player name column in weekly data.")
+    df["player"] = df[player_col].astype(str)
+
+    team_col = _first_nonempty_col(df, "recent_team", "team", "posteam")
+    df["team"] = df[team_col].astype(str) if team_col else ""
+
+    opp_col = _first_nonempty_col(df, "opponent", "opp", "defteam", "opp_team")
+    df["opponent"] = df[opp_col].astype(str) if opp_col else ""
+
+    pos_col = _first_nonempty_col(df, "position", "pos")
+    df["position"] = df[pos_col].astype(str) if pos_col else ""
+
+    week_col = _first_nonempty_col(df, "week", "game_week")
+    if not week_col:
+        df["week"] = range(1, len(df) + 1)
+        week_col = "week"
+
+    df["pressures"] = _nz_float(df, ["pressures", "qb_hits", "def_pressures"])
+    df["prwin"] = _nz_float(df, ["prwin", "pass_rush_win_rate", "prwin_pct"]).clip(lower=0.0, upper=1.0)
+    df["pass_rush_snaps"] = _nz_float(df, ["pass_rushes", "pass_rush_snaps", "prsnaps"])
+
+    agg = (
+        df.groupby(["player", "team", "opponent", "position"], as_index=False)
+        .agg(
+            pressures=("pressures", "sum"),
+            prwin=("prwin", "mean"),
+            pass_rush_snaps=("pass_rush_snaps", "sum"),
+            games=(week_col, "nunique"),
+        )
+    )
+
+    agg["pressures_per_game"] = agg["pressures"] / agg["games"].clip(lower=1)
+
+    team_rates = _team_dropback_sack_rates(season - 1)
+    agg = agg.merge(team_rates, left_on="opponent", right_on="team", how="left", suffixes=("", "_opp"))
+
+    league_dropbacks = team_rates["dropbacks_per_game"].mean() if not team_rates.empty else 35.0
+    league_sack_rate = team_rates["sack_rate"].mean() if not team_rates.empty else 0.07
+
+    agg["opp_dropbacks"] = agg["dropbacks_per_game"].fillna(league_dropbacks)
+    agg["opp_sack_rate_allowed"] = agg["sack_rate"].fillna(league_sack_rate)
+
+    return agg[
+        [
+            "player",
+            "team",
+            "opponent",
+            "position",
+            "pressures_per_game",
+            "prwin",
+            "pass_rush_snaps",
+            "opp_dropbacks",
+            "opp_sack_rate_allowed",
+        ]
+    ]
 

--- a/gamblebot/filters.py
+++ b/gamblebot/filters.py
@@ -1,0 +1,58 @@
+"""Filtering utilities for player reports."""
+from __future__ import annotations
+
+import pandas as pd
+from typing import Iterable
+
+
+def _normalize_positions(pos: Iterable[str]) -> list[str]:
+    return [p.strip().upper() for p in pos if p and isinstance(p, str)]
+
+
+def apply_filters(
+    df: pd.DataFrame,
+    *,
+    positions: list[str],
+    min_recent_opps: float,
+    exclude_injured: bool,
+    season: int,
+    week: int,
+) -> pd.DataFrame:
+    """Filter offensive players for the 2+ TD report.
+
+    Parameters mirror those in the CLI. Injury filtering is a stub that currently
+    acts as a no-op but preserves the interface for future enhancement.
+    """
+    out = df.copy()
+    if positions:
+        pos_set = set(_normalize_positions(positions))
+        if "position" in out.columns:
+            out = out[out["position"].str.upper().isin(pos_set)]
+    if min_recent_opps is not None and "recent_opps" in out.columns:
+        out = out[out["recent_opps"] >= float(min_recent_opps)]
+    # Injury filtering could be added here in the future. For now this is a no-op.
+    return out.reset_index(drop=True)
+
+
+def apply_passrush_filters(
+    df: pd.DataFrame,
+    *,
+    positions: list[str],
+    min_passrush_snaps: float,
+    exclude_injured: bool,
+    season: int,
+    week: int,
+) -> pd.DataFrame:
+    """Filter defensive players for the sacks report.
+
+    Currently filters by position and pass-rush snap volume. Injury filtering is
+    a placeholder for future integration with injury reports.
+    """
+    out = df.copy()
+    if positions:
+        pos_set = set(_normalize_positions(positions))
+        if "position" in out.columns:
+            out = out[out["position"].str.upper().isin(pos_set)]
+    if min_passrush_snaps is not None and "pass_rush_snaps" in out.columns:
+        out = out[out["pass_rush_snaps"] >= float(min_passrush_snaps)]
+    return out.reset_index(drop=True)

--- a/gamblebot/model.py
+++ b/gamblebot/model.py
@@ -1,4 +1,4 @@
-"""Simple probabilistic model for 2+ TD using Poisson + empirical Bayes."""
+"""Simple probabilistic models for touchdown and sack props."""
 from __future__ import annotations
 
 import numpy as np
@@ -31,4 +31,31 @@ def add_model_probability(features_df: pd.DataFrame) -> pd.DataFrame:
     df["model_prob"] = np.clip(model_prob, 0.0, 0.30)
 
     return df[["player", "team", "position", "recent_opps", "model_prob"]]
+
+
+def add_sack_model_probability(features_df: pd.DataFrame) -> pd.DataFrame:
+    """Estimate P(≥1 sack) for defenders using a Poisson model."""
+    df = features_df.copy()
+
+    pressure_rate = (
+        pd.to_numeric(df["pressures_per_game"], errors="coerce").fillna(0.0)
+        / pd.to_numeric(df["pass_rush_snaps"], errors="coerce").fillna(1.0)
+    )
+    prwin = pd.to_numeric(df["prwin"], errors="coerce").fillna(0.0)
+    opp_drop = pd.to_numeric(df["opp_dropbacks"], errors="coerce").fillna(30.0)
+    opp_sack_rate = pd.to_numeric(df["opp_sack_rate_allowed"], errors="coerce").fillna(0.07)
+
+    lam = pressure_rate * prwin * opp_drop * opp_sack_rate
+    poisson_p_ge1 = 1.0 - np.exp(-lam.clip(lower=0.0))
+
+    # Empirical-Bayes shrinkage toward league average
+    lam0 = float(lam.mean()) if len(lam) else 0.05
+    p0 = 1.0 - np.exp(-lam0)
+    snaps = pd.to_numeric(df["pass_rush_snaps"], errors="coerce").fillna(0.0)
+    prior_strength = 200.0  # pseudo-snaps
+    w = snaps / (snaps + prior_strength)
+    model_prob = w * poisson_p_ge1 + (1.0 - w) * p0
+
+    df["model_prob"] = np.clip(model_prob, 0.0, 0.95)
+    return df[["player", "team", "opponent", "position", "pass_rush_snaps", "model_prob"]]
 

--- a/gamblebot/reporting.py
+++ b/gamblebot/reporting.py
@@ -23,18 +23,34 @@ def format_percentage(x: float) -> str:
 
 def display_report(df: pd.DataFrame) -> None:
     table = Table(show_header=True, header_style="bold")
-    for col in ["team", "player", "model_prob", "odds", "implied_prob", "edge", "stake_units"]:
+    cols = [
+        c
+        for c in [
+            "team",
+            "player",
+            "opponent",
+            "model_prob",
+            "line",
+            "odds",
+            "implied_prob",
+            "edge",
+            "stake_units",
+        ]
+        if c in df.columns
+    ]
+    for col in cols:
         table.add_column(col)
     for _, row in df.iterrows():
-        table.add_row(
-            row["team"],
-            row["player"],
-            format_percentage(row["model_prob"]),
-            str(row["odds"]),
-            format_percentage(row["implied_prob"]),
-            format_percentage(row["edge"]),
-            f"{row['stake_units']:.2f}",
-        )
+        cells = []
+        for col in cols:
+            val = row[col]
+            if col in {"model_prob", "implied_prob", "edge"}:
+                cells.append(format_percentage(float(val)))
+            elif col == "stake_units":
+                cells.append(f"{float(val):.2f}")
+            else:
+                cells.append(str(val))
+        table.add_row(*cells)
     console.print(table)
 
 


### PR DESCRIPTION
## Summary
- extend CLI with new `sacks` report for defenders to record 1+ sack
- fetch and normalize sack odds and compute pass-rush model probabilities
- add defensive filters and dynamic reporting for team/opponent/line

## Testing
- `python -m py_compile gamblebot/cli.py gamblebot/features.py gamblebot/model.py gamblebot/odds.py gamblebot/reporting.py gamblebot/filters.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb3cfa5ee48327a3c991756ca21b21