### PR TITLE
Add prediction logging, evaluation CLI, and high-probability report

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,17 @@ export THEODDS_API_KEY="your_api_key_here"
 Run commands with Poetry from the project root:
 
 ```bash
+# Value-focused edge report
 poetry run gamblebot report --season <YEAR> --week <WEEK>
+
+# Highest-probability TD scorers
+poetry run gamblebot likely --season <YEAR> --week <WEEK>
+```
+
+After games are played you can evaluate logged predictions:
+
+```
+poetry run gamblebot evaluate --season <YEAR> --week <WEEK>
 ```
 
 ---
@@ -32,10 +42,19 @@ poetry run gamblebot report --season <YEAR> --week <WEEK>
 * `--csv PATH`: Export final table to CSV.
 * `--html PATH`: Export final table to HTML.
 * `--png PATH`: Export final table to PNG.
+* `--log PATH` (default: `predictions.csv`): Append predictions to this CSV for later evaluation.
 * `--dump-odds` (flag): Print **all posted 2+ TD lines** (by book) for the chosen week and exit (great for sanity checks).
 * `--positions STR` (default: `RB,WR,TE`): Comma-separated positions to include (add `QB` to include quarterbacks).
 * `--min-recent-opps FLOAT` (default: `3.0`): Minimum recent average opportunities (rush attempts + targets) over the last few games; filters out low-usage players.
 * `--no-exclude-injured` (flag): Disable the injury filter (by default, players listed as out/doubtful/IR/PUP/etc for that week are excluded).
+
+The `likely` subcommand accepts the same options (except `--dump-odds`) but sorts by `model_prob` instead of `edge`.
+
+### Evaluation
+
+* `--season INT` **(required)**: Season year to evaluate.
+* `--week INT` **(required)**: Week number to evaluate.
+* `--log PATH` (default: `predictions.csv`): Prediction log file to read.
 
 ---
 
@@ -77,6 +96,18 @@ Show every posted **2+ TD** price (debug/sanity check):
 
 ```bash
 poetry run gamblebot report --season 2025 --week 1 --dump-odds
+```
+
+List the most likely 2+ TD scorers (highest model probabilities):
+
+```bash
+poetry run gamblebot likely --season 2025 --week 1 --top 20
+```
+
+Evaluate prior predictions once results are known:
+
+```
+poetry run gamblebot evaluate --season 2025 --week 1
 ```
 
 ---

--- a/gamblebot/__init__.py
+++ b/gamblebot/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     "features",
     "model",
     "odds",
+    "evaluation",
     "reporting",
     "staking",
 ]

--- a/gamblebot/evaluation.py
+++ b/gamblebot/evaluation.py
@@ -1,0 +1,52 @@
+"""Utilities for logging predictions and evaluating outcomes."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+import pandas as pd
+
+from . import data
+
+DEFAULT_LOG = Path("predictions.csv")
+
+
+def record_predictions(df: pd.DataFrame, season: int, week: int, path: Path = DEFAULT_LOG) -> None:
+    """Append predictions to a CSV log with season/week metadata."""
+    log_df = df.copy()
+    log_df["season"] = season
+    log_df["week"] = week
+    log_df["timestamp"] = pd.Timestamp.utcnow()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    header = not path.exists()
+    log_df.to_csv(path, mode="a", header=header, index=False)
+
+
+def evaluate_predictions(season: int, week: int, path: Path = DEFAULT_LOG) -> Tuple[pd.DataFrame, dict]:
+    """Evaluate logged predictions against actual 2+ TD outcomes."""
+    if not path.exists():
+        return pd.DataFrame(), {}
+    preds = pd.read_csv(path)
+    preds = preds[(preds["season"] == season) & (preds["week"] == week)]
+    if preds.empty:
+        return preds, {}
+    weekly = data.load_weekly_player_stats(season, week=week)
+    weekly = weekly.assign(
+        tds=pd.to_numeric(weekly.get("rushing_td", 0), errors="coerce").fillna(0)
+        + pd.to_numeric(weekly.get("receiving_td", 0), errors="coerce").fillna(0)
+    )[["player", "tds"]]
+    merged = preds.merge(weekly, on="player", how="left")
+    merged["tds"] = merged["tds"].fillna(0).astype(int)
+    merged["hit"] = merged["tds"] >= 2
+    merged["profit"] = merged.apply(
+        lambda r: r["stake_units"] * (r["odds"] - 1) if r["hit"] else -r["stake_units"],
+        axis=1,
+    )
+    merged["brier"] = (merged["model_prob"] - merged["hit"].astype(float)) ** 2
+    metrics = {
+        "n": int(len(merged)),
+        "hit_rate": float(merged["hit"].mean()),
+        "roi": float(merged["profit"].sum() / merged["stake_units"].sum()) if merged["stake_units"].sum() else 0.0,
+        "brier": float(merged["brier"].mean()),
+    }
+    return merged, metrics


### PR DESCRIPTION
## Summary
- log weekly report predictions to `predictions.csv`
- add `evaluate` command to compute hit rate, ROI, and Brier score
- introduce `likely` command to list top TD scorers by model probability

## Testing
- `pytest`
- `python -m gamblebot.cli --help`
- `python -m gamblebot.cli likely --help`


------
https://chatgpt.com/codex/tasks/task_e_68bcb0c0a5cc832790575d07691e93b3